### PR TITLE
Improve error handling for native cleanup

### DIFF
--- a/files/src/nativeFileSupported2Main/kotlin/space/iseki/executables/common/NativeFileDataAccessor.kt
+++ b/files/src/nativeFileSupported2Main/kotlin/space/iseki/executables/common/NativeFileDataAccessor.kt
@@ -104,6 +104,7 @@ private class NativeFileDataAccessorImpl(private val nativePath: String) : Closa
     }
 
     override fun toString(): String = "NativeFileDataAccessor(path=$nativePath)"
+    @OptIn(ExperimentalNativeApi::class)
     override fun doClose() {
         if (beginPtr == null) return
         if (munmap(beginPtr, size.toUInt()) == -1) {

--- a/files/src/nativeFileSupported2Main/kotlin/space/iseki/executables/common/NativeFileDataAccessor.kt
+++ b/files/src/nativeFileSupported2Main/kotlin/space/iseki/executables/common/NativeFileDataAccessor.kt
@@ -31,6 +31,7 @@ import platform.posix.strerror
 import space.iseki.executables.share.ClosableDataAccessor
 import kotlin.experimental.ExperimentalNativeApi
 import kotlin.native.ref.createCleaner
+import kotlin.native.terminateWithUnhandledException
 
 @Suppress("DELEGATED_MEMBER_HIDES_SUPERTYPE_OVERRIDE")
 @OptIn(ExperimentalNativeApi::class)
@@ -105,6 +106,11 @@ private class NativeFileDataAccessorImpl(private val nativePath: String) : Closa
     override fun toString(): String = "NativeFileDataAccessor(path=$nativePath)"
     override fun doClose() {
         if (beginPtr == null) return
-        if (munmap(beginPtr, size.toUInt()) == -1) throw translateErrorImmediately("munmap")
+        if (munmap(beginPtr, size.toUInt()) == -1) {
+            val errorCode = errno
+            val errorMessage = strerror(errorCode)?.toKStringFromUtf8().orEmpty()
+            val ise = IllegalStateException("munmap failed: errno=$errorCode, message=$errorMessage")
+            terminateWithUnhandledException(ise)
+        }
     }
 }

--- a/files/src/nativeFileSupportedMain/kotlin/space/iseki/executables/common/NativeFileDataAccessor.kt
+++ b/files/src/nativeFileSupportedMain/kotlin/space/iseki/executables/common/NativeFileDataAccessor.kt
@@ -30,6 +30,7 @@ import platform.posix.strerror
 import space.iseki.executables.share.ClosableDataAccessor
 import kotlin.experimental.ExperimentalNativeApi
 import kotlin.native.ref.createCleaner
+import kotlin.native.terminateWithUnhandledException
 
 @Suppress("DELEGATED_MEMBER_HIDES_SUPERTYPE_OVERRIDE")
 @OptIn(ExperimentalNativeApi::class)
@@ -104,7 +105,12 @@ private class NativeFileDataAccessorImpl(private val nativePath: String) : Closa
     override fun toString(): String = "NativeFileDataAccessor(path=$nativePath)"
     override fun doClose() {
         if (beginPtr == null) return
-        if (munmap(beginPtr, size.toULong()) == -1) throw translateErrorImmediately("munmap")
+        if (munmap(beginPtr, size.toULong()) == -1) {
+            val errorCode = errno
+            val errorMessage = strerror(errorCode)?.toKStringFromUtf8().orEmpty()
+            val ise = IllegalStateException("munmap failed: errno=$errorCode, message=$errorMessage")
+            terminateWithUnhandledException(ise)
+        }
     }
 }
 

--- a/files/src/nativeFileSupportedMain/kotlin/space/iseki/executables/common/NativeFileDataAccessor.kt
+++ b/files/src/nativeFileSupportedMain/kotlin/space/iseki/executables/common/NativeFileDataAccessor.kt
@@ -103,6 +103,7 @@ private class NativeFileDataAccessorImpl(private val nativePath: String) : Closa
     }
 
     override fun toString(): String = "NativeFileDataAccessor(path=$nativePath)"
+    @OptIn(ExperimentalNativeApi::class)
     override fun doClose() {
         if (beginPtr == null) return
         if (munmap(beginPtr, size.toULong()) == -1) {


### PR DESCRIPTION
Terminate program on native cleanup failures (CloseHandle, UnmapViewOfFile, munmap) to correctly handle unrecoverable states.

Native cleanup operations like closing handles or unmapping memory should never fail under normal circumstances. If they do, it indicates a severe, unrecoverable program state (e.g., memory corruption). The previous handling either ignored failures or threw recoverable exceptions, which was incorrect. This change ensures the program terminates immediately with a clear error, preventing further unpredictable behavior.